### PR TITLE
bugfix: prevent error when predict one point

### DIFF
--- a/R/predict.ridgeLinear.R
+++ b/R/predict.ridgeLinear.R
@@ -29,9 +29,9 @@ predict.ridgeLinear <- function(object, newdata,
     hasintercept <- attr(tt, "intercept")
     ll <- attr(tt, "term.labels")
     if(hasintercept)
-      mm <- cbind(1, X[,ll])
+      mm <- cbind(1, X[,ll,drop=FALSE])
     else
-      mm <- X[,ll]
+      mm <- X[,ll,drop=FALSE]
     beta <- coef(object, all.coef = all.coef)
     if(all.coef)
       res <- apply(beta, 1, function(x){drop(as.matrix(mm) %*% x)})


### PR DESCRIPTION
add `drop=FALSE` so that `as.matrix(mm) %*% beta` doesn't fail when `X` has only one row